### PR TITLE
Add once() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ See [using the package](docs/usage.md).
 | `ray().newScreen()` | Start a new screen |
 | `ray().newScreen('title')` | Start a new named screen |
 | `ray(…).notify(message)` | Display a notification |
+| `ray().once(arg1, …)` | Only send a payload once when in a loop |
 | `ray(…).pass(variable)` | Display something in Ray and return the value instead of a Ray instance |
 | `ray().pause()` | Pause code execution within your code; must be called using `await` |
 | `ray(…).remove()` | Remove an item from Ray   |

--- a/src/Ray.ts
+++ b/src/Ray.ts
@@ -591,6 +591,25 @@ export class Ray extends Mixin(RayColors, RaySizes) {
         return this;
     }
 
+    public once(...args: any[]): this {
+        const frame = this.getOriginFrame();
+
+        this.limitOrigin = <OriginData>{
+            function_name: frame?.getFunctionName(),
+            file: frame?.getFileName(),
+            line_number: frame?.getLineNumber(),
+            hostname: Hostname.get(),
+        };
+
+        Ray.limiters.initialize(this.limitOrigin, 1);
+
+        if (args.length > 0) {
+            return this.send(...args);
+        }
+
+        return this;
+    }
+
     public sendCustom(content: string, label = ''): this {
         const payload = new CustomPayload(content, label);
 

--- a/tests/Ray.test.ts
+++ b/tests/Ray.test.ts
@@ -662,3 +662,30 @@ it('can handle multiple consecutive calls to limit', () => {
 
     expect(client.sentPayloads()).toMatchSnapshot();
 });
+
+it('sends a payload once when called with arguments', () => {
+    for (let i = 0; i < 5; i++) {
+        getNewRay().once(i);
+    }
+
+    expect(client.sentPayloads().length).toBe(1);
+    expect(client.sentPayloads()[0]['payloads'][0]['content']['values']).toStrictEqual([0]);
+});
+
+it('sends a payload once when called without arguments', () => {
+    for (let i = 0; i < 5; i++) {
+        getNewRay().once().text(`${i}`);
+    }
+
+    expect(client.sentPayloads().length).toBe(1);
+    expect(client.sentPayloads()[0]['payloads'][0]['content']['content']).toStrictEqual('0');
+});
+
+it('sends a payload once while allowing calls to limit', () => {
+    for (let i = 0; i < 5; i++) {
+        getNewRay().once(i);
+        getNewRay().limit(5).text(`${i}`);
+    }
+
+    expect(client.sentPayloads().length).toBe(6);
+});


### PR DESCRIPTION
This PR adds the `once()` method.  It replicates spatie/ray PR 481.