### PR TITLE
Make exception/error payloads red by default

### DIFF
--- a/src/Ray.ts
+++ b/src/Ray.ts
@@ -302,7 +302,11 @@ export class Ray extends Mixin(RayColors, RaySizes) {
     public error(err: Error): this {
         const payload = new ErrorPayload(err, 'Error');
 
-        return this.sendRequest(payload);
+        this.sendRequest(payload);
+
+        this.red();
+
+        return this;
     }
 
     public event(eventName: string, data: any[] = []): this {
@@ -314,7 +318,11 @@ export class Ray extends Mixin(RayColors, RaySizes) {
     public exception(err: Error, meta: Record<string, unknown> = {}): this {
         const payload = new ExceptionPayload(err, meta);
 
-        return this.sendRequest(payload);
+        this.sendRequest(payload);
+
+        this.red();
+
+        return this;
     }
 
     public showWhen(booleanOrCallable: boolean | BoolFunction): this {

--- a/tests/__snapshots__/Ray.test.ts.snap
+++ b/tests/__snapshots__/Ray.test.ts.snap
@@ -1371,6 +1371,24 @@ Array [
     ],
     "uuid": "fakeUuid",
   },
+  Object {
+    "meta": Array [],
+    "payloads": Array [
+      Object {
+        "content": Object {
+          "color": "red",
+        },
+        "origin": Object {
+          "file": "/tests/Ray.test.ts",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "color",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
 ]
 `;
 
@@ -1432,6 +1450,24 @@ Array [
     ],
     "uuid": "fakeUuid",
   },
+  Object {
+    "meta": Array [],
+    "payloads": Array [
+      Object {
+        "content": Object {
+          "color": "red",
+        },
+        "origin": Object {
+          "file": "/tests/Ray.test.ts",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "color",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
 ]
 `;
 
@@ -1467,6 +1503,24 @@ Array [
           "line_number": 999,
         },
         "type": "exception",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
+  Object {
+    "meta": Array [],
+    "payloads": Array [
+      Object {
+        "content": Object {
+          "color": "red",
+        },
+        "origin": Object {
+          "file": "/tests/Ray.test.ts",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "color",
       },
     ],
     "uuid": "fakeUuid",


### PR DESCRIPTION
This PR replicates functionality in spatie/ray by making exception and error payloads red by default.