### PR TITLE
Fix limit() and once()

### DIFF
--- a/src/Ray.ts
+++ b/src/Ray.ts
@@ -670,7 +670,7 @@ export class Ray extends Mixin(RayColors, RaySizes, RayScreenColors) {
     }
 
     public limit(count: number): this {
-        const frame = this.getOriginFrame();
+        const frame = this.getCaller();
 
         this.limitOrigin = <any>{
             function_name: frame?.getFunctionName(),
@@ -686,7 +686,7 @@ export class Ray extends Mixin(RayColors, RaySizes, RayScreenColors) {
     }
 
     public once(...args: any[]): this {
-        const frame = this.getOriginFrame();
+        const frame = this.getCaller();
 
         this.limitOrigin = <any>{
             function_name: frame?.getFunctionName(),

--- a/tests/Ray.test.ts
+++ b/tests/Ray.test.ts
@@ -657,7 +657,7 @@ it('only limits the number of payloads sent from the line that calls limit', () 
         getNewRay().send(`unlimited loop iteration ${i}`);
     }
 
-    expect(client.sentPayloads().length).toBe(iterations);
+    expect(client.sentPayloads().length).toBe(iterations + limit);
 });
 
 it('can handle multiple consecutive calls to limit', () => {
@@ -672,33 +672,34 @@ it('can handle multiple consecutive calls to limit', () => {
     expect(client.sentPayloads()).toMatchSnapshot();
 });
 
-// it('sends a payload once when called with arguments', () => {
-//     for (let i = 0; i < 5; i++) {
-//         getNewRay().once(i);
-//     }
+it('sends a payload once when called with arguments', () => {
+    const r = getNewRay();
 
-//     expect(client.sentPayloads().length).toBe(1);
-//     expect(client.sentPayloads()[0]['payloads'][0]['content']['values']).toStrictEqual([0]);
-// });
+    for (let i = 0; i < 5; i++) {
+        r.once(i);
+    }
 
-// it('sends a payload once when called without arguments', () => {
-//     for (let i = 0; i < 5; i++) {
-//         getNewRay().once().text(`${i}`);
-//     }
+    expect(client.sentPayloads().length).toBe(1);
+    expect(client.sentPayloads()[0]['payloads'][0]['content']['values']).toStrictEqual([0]);
+});
 
-//     expect(client.sentPayloads().length).toBe(1);
-//     expect(client.sentPayloads()[0]['payloads'][0]['content']['content']).toStrictEqual('0');
-// });
+it('sends a payload once when called without arguments', () => {
+    for (let i = 0; i < 5; i++) {
+        getNewRay().once().text(`${i}`);
+    }
 
-// it('sends a payload once while allowing calls to limit', () => {
-//     for (let i = 0; i < 5; i++) {
-//         getNewRay().once(i);
-//         getNewRay().limit(5).text(`${i}`);
-//     }
+    expect(client.sentPayloads().length).toBe(1);
+    expect(client.sentPayloads()[0]['payloads'][0]['content']['content']).toStrictEqual('0');
+});
 
-//     console.log(client);
-//     expect(client.sentPayloads().length).toBe(6);
-// });
+it('sends a payload once while allowing calls to limit', () => {
+    for (let i = 0; i < 5; i++) {
+        getNewRay().once(i);
+        getNewRay().limit(5).text(`${i}`);
+    }
+
+    expect(client.sentPayloads().length).toBe(6);
+});
 
 it('can conditionally send payloads using if with a truthy conditional and without a callback', () => {
     for (let i = 0; i < 10; i++) {

--- a/tests/__snapshots__/Ray.test.ts.snap
+++ b/tests/__snapshots__/Ray.test.ts.snap
@@ -149,7 +149,90 @@ exports[`can chain multiple if calls with callbacks together 1`] = `
 ]
 `;
 
-exports[`can handle multiple consecutive calls to limit 1`] = `[]`;
+exports[`can handle multiple consecutive calls to limit 1`] = `
+[
+  {
+    "meta": [],
+    "payloads": [
+      {
+        "content": {
+          "values": [
+            "limited loop A iteration 0",
+          ],
+        },
+        "origin": {
+          "file": "/test/file.js",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "log",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
+  {
+    "meta": [],
+    "payloads": [
+      {
+        "content": {
+          "values": [
+            "limited loop B iteration 0",
+          ],
+        },
+        "origin": {
+          "file": "/test/file.js",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "log",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
+  {
+    "meta": [],
+    "payloads": [
+      {
+        "content": {
+          "values": [
+            "limited loop A iteration 1",
+          ],
+        },
+        "origin": {
+          "file": "/test/file.js",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "log",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
+  {
+    "meta": [],
+    "payloads": [
+      {
+        "content": {
+          "values": [
+            "limited loop B iteration 1",
+          ],
+        },
+        "origin": {
+          "file": "/test/file.js",
+          "function_name": "xxxx",
+          "hostname": "fake-hostname",
+          "line_number": 999,
+        },
+        "type": "log",
+      },
+    ],
+    "uuid": "fakeUuid",
+  },
+]
+`;
 
 exports[`can send additional payloads from the sent payload callback 1`] = `
 [


### PR DESCRIPTION
This PR fixes `limit()` and `once()` not functioning correctly, as well as updating and adding tests.