### PR TITLE
Add initSettings() to NodeRay

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Ray.useDefaultSettings({ port: 3000 });
 // ...and use ray() as normal
 ```
 
+**When using NodeJS,** you must call `await Ray.initSettings()` to initialize the settings before using `ray()`.
+This is not necessary when using the browser bundle.
+
 ```js
 ray('a string');
 

--- a/src/RayNode.ts
+++ b/src/RayNode.ts
@@ -7,14 +7,28 @@ import { ImagePayload } from '@/Payloads/ImagePayload';
 import { NodeInfoPayload } from '@/Payloads/NodeInfoPayload';
 import { NodeMeasurePayload } from '@/Payloads/NodeMeasurePayload';
 import { Ray as BaseRay } from '@/Ray';
+import { Settings } from '@/Settings/Settings';
 import { SettingsFactory } from '@/Settings/SettingsFactory';
 import { NodeStopwatch } from '@/Stopwatch/NodeStopwatch';
 import { existsSync } from 'node:fs';
 
 // @ts-ignore
 export class Ray extends BaseRay {
-    public static async create(client: Client | null = null, uuid: string | null = null): Promise<Ray> {
-        const settings = await SettingsFactory.createFromConfigFile();
+    protected static settingsInstance: Settings | null = null;
+
+    public static async initSettings(): Promise<void> {
+        Ray.settingsInstance = await SettingsFactory.createFromConfigFile();
+    }
+
+    public static create(client: Client | null = null, uuid: string | null = null): Ray {
+        const settings =
+            Ray.settingsInstance ??
+            new Settings({
+                host: 'localhost',
+                port: 23517,
+                enable: true,
+                always_send_raw_values: false,
+            });
 
         return new this(settings, client, uuid);
     }
@@ -88,5 +102,5 @@ export class Ray extends BaseRay {
 }
 
 export const ray = (...args: any[]) => {
-    return Ray.create().then(r => r.send(...args));
+    return Ray.create().send(...args);
 };

--- a/src/Settings/SettingsFactory.ts
+++ b/src/Settings/SettingsFactory.ts
@@ -25,7 +25,7 @@ export class SettingsFactory {
     }
 
     public async getSettingsFromConfigFile(configDirectory: string | null = null) {
-        const configFilePath = await this.searchConfigFiles(configDirectory);
+        const configFilePath = this.searchConfigFiles(configDirectory);
 
         if (!(await exists(configFilePath))) {
             return {};
@@ -43,20 +43,20 @@ export class SettingsFactory {
         return options as RaySettings;
     }
 
-    protected async searchConfigFiles(configDirectory: string | null = null): Promise<string> {
+    protected searchConfigFiles(configDirectory: string | null = null): string {
         if (configDirectory === null) {
             configDirectory = '';
         }
 
         if (typeof this.cache[configDirectory] === 'undefined') {
-            this.cache[configDirectory] = await this.searchConfigFilesOnDisk(configDirectory);
+            this.cache[configDirectory] = this.searchConfigFilesOnDisk(configDirectory);
         }
 
         return this.cache[configDirectory];
     }
 
-    protected async searchConfigFilesOnDisk(configDirectory: string | null = null): Promise<string> {
-        const configFn = await findUp('ray.config.js', {
+    protected searchConfigFilesOnDisk(configDirectory: string | null = null): string {
+        const configFn = findUp('ray.config.js', {
             type: 'file',
             cwd: configDirectory ?? process.cwd(),
         });

--- a/src/lib/findUp.ts
+++ b/src/lib/findUp.ts
@@ -75,7 +75,7 @@ function findUpMultipleSync(name, options: any = {}) {
     return matches;
 }
 
-export async function findUp(name, options: any = {}) {
+export function findUp(name, options: any = {}) {
     const matches = findUpMultipleSync(name, { ...options, limit: 1 });
     return matches[0];
 }


### PR DESCRIPTION
This PR adds `NodeRay.initSettings()` and removes `async` from the `NodeRay.create()` method.